### PR TITLE
fix: update brace-expansion security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,9 +1656,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
## Summary\n- update transitive brace-expansion to patched maintenance releases\n- preserve existing parent dependency constraints\n\n## Validation\n- package-lock JSON validation\n- `npm ci --dry-run --ignore-scripts`\n- verified no vulnerable brace-expansion tarball references remain